### PR TITLE
fix: Align active plan check logic and verify view

### DIFF
--- a/app/Http/Controllers/PricingController.php
+++ b/app/Http/Controllers/PricingController.php
@@ -11,9 +11,7 @@ class PricingController extends Controller
     public function show()
     {
         $user = Auth::user();
-        $hasActivePlan = Transaction::where('user_id', $user->id)
-                                    ->where('status', 'SUCCESS')
-                                    ->exists();
+        $hasActivePlan = Transaction::where('user_id', $user->id)->exists();
 
         return view('resume-build', ['hasActivePlan' => $hasActivePlan]);
     }


### PR DESCRIPTION
This commit ensures the logic for checking if a user has an active plan is consistent with the user's latest request and that the UI implements it correctly.

- The `PricingController` now checks for the existence of *any* transaction for a user, not just successful ones, to determine if they have a plan.
- Verified that the Javascript popup on the pricing page (`/resume-build`) correctly uses this logic to alert users who already have a plan.